### PR TITLE
Add #![feature(const_fn_union)] when needed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,7 @@
 #![cfg_attr(feature = "const-fn", feature(const_fn))]
 #![cfg_attr(feature = "const-fn", feature(const_manually_drop_new))]
 #![cfg_attr(feature = "const-fn", feature(untagged_unions))]
+#![cfg_attr(feature = "const-fn", feature(const_fn_union))]
 #![cfg_attr(feature = "smaller-atomics", feature(core_intrinsics))]
 #![no_std]
 


### PR DESCRIPTION
This crate currently fails to compile on the newest nightly when using the "const-fn" feature because unions in const fns now require a feature flag. This change adds the feature flag when using that feature.